### PR TITLE
Mn/events grid tiles

### DIFF
--- a/src/components/UI/Footer.svelte
+++ b/src/components/UI/Footer.svelte
@@ -62,7 +62,11 @@
           </li>
         </ul>
       </div>
+<<<<<<< HEAD
       <div class="column is-2">
+=======
+      <div class="column">
+>>>>>>> Add footer component
         <div class="content">
           Stichting Love Foundation
           <br />
@@ -82,6 +86,7 @@
         </div>
       </div>
       <div class="column" />
+<<<<<<< HEAD
       <div class="column is-3 is-flex">
         <div class="columns is-mobile low">
           <div class="column"><a href="https://www.instagram.com">
@@ -102,6 +107,8 @@
           </a>
         </div>
       </div>
+=======
+>>>>>>> Add footer component
     </div>
   </div>
 </footer>

--- a/src/components/UI/Grid/GridGroup.svelte
+++ b/src/components/UI/Grid/GridGroup.svelte
@@ -3,6 +3,8 @@
   export let eventGroup = [];
   export let groupIndex = null;
   let isEven = groupIndex % 2 == 0;
+
+  // FIX ME: For ensuring order is maintained, the array needs to be reversed when isEven = true
 </script>
 
 <style lang="scss">

--- a/src/components/UI/Grid/GridGroup.svelte
+++ b/src/components/UI/Grid/GridGroup.svelte
@@ -1,0 +1,80 @@
+<script>
+  import GridItem from "./GridItem.svelte";
+  export let eventGroup = [];
+  export let groupIndex = null;
+  console.log(groupIndex);
+</script>
+
+<style lang="scss">
+  .test {
+    flex-flow: wrap !important;
+  }
+</style>
+
+{#if groupIndex % 2 === 0}
+  {#if eventGroup.length === 5}
+    <GridItem
+      id={eventGroup[0].id}
+      imageUrl={eventGroup[0].imageUrls.full_url}
+      title={eventGroup[0].title}
+      hub={eventGroup[0].hub}
+      cardClass={'is-parent is-6'} />
+    <div class="tile is-parent is-6 is-vertical test">
+      {#each eventGroup.slice(1, eventGroup.length) as event, i (event.id)}
+        <GridItem
+          id={event.id}
+          imageUrl={event.imageUrls.full_url}
+          title={event.title}
+          hub={event.hub}
+          cardClass={'is-6 '} />
+      {/each}
+    </div>
+  {:else}
+    <GridItem
+      id={eventGroup[0].id}
+      imageUrl={eventGroup[0].imageUrls.full_url}
+      title={eventGroup[0].title}
+      hub={eventGroup[0].hub}
+      cardClass={'is-parent is-6'} />
+    <div class="tile is-parent is-6 is-vertical test">
+      {#each eventGroup.slice(1, eventGroup.length) as event, i (event.id)}
+        <GridItem
+          id={event.id}
+          imageUrl={event.imageUrls.full_url}
+          title={event.title}
+          hub={event.hub}
+          cardClass={'is-6 is-alone'} />
+      {/each}
+    </div>
+  {/if}
+{:else}
+  {#if eventGroup.length === 5}
+    <div class="tile is-parent is-6 is-vertical test">
+      {#each eventGroup.slice(0, eventGroup.length - 1) as event, i (event.id)}
+        <GridItem
+          id={event.id}
+          imageUrl={event.imageUrls.full_url}
+          title={event.title}
+          hub={event.hub}
+          cardClass={'is-6'} />
+      {/each}
+    </div>
+    <GridItem
+      id={eventGroup[4].id}
+      imageUrl={eventGroup[4].imageUrls.full_url}
+      title={eventGroup[4].title}
+      hub={eventGroup[4].hub}
+      cardClass={'is-parent is-6'} />
+  {:else}
+    <div class="tile is-parent is-6 is-vertical test">
+      {#each eventGroup.slice(0, eventGroup.length) as event, i (event.id)}
+        <GridItem
+          id={event.id}
+          imageUrl={event.imageUrls.full_url}
+          title={event.title}
+          hub={event.hub}
+          cardClass={'is-6'} />
+      {/each}
+    </div>
+  {/if}
+{/if}

--- a/src/components/UI/Grid/GridGroup.svelte
+++ b/src/components/UI/Grid/GridGroup.svelte
@@ -2,79 +2,38 @@
   import GridItem from "./GridItem.svelte";
   export let eventGroup = [];
   export let groupIndex = null;
-  console.log(groupIndex);
+  let isEven = groupIndex % 2 == 0;
 </script>
 
 <style lang="scss">
   .test {
     flex-flow: wrap !important;
   }
+  // grid-template:
+  //   "a b b" 40px
+  //   "a b b" 40px / 1fr 1fr 1fr;
+
+  // grid-template: :nth-child(n+1)
+  //   "b b a" 40px
+  //   "b b a" 40px / 1fr 1fr 1fr;
+
+
 </style>
 
-{#if groupIndex % 2 === 0}
-  {#if eventGroup.length === 5}
-    <GridItem
-      id={eventGroup[0].id}
-      imageUrl={eventGroup[0].imageUrls.full_url}
-      title={eventGroup[0].title}
-      hub={eventGroup[0].hub}
-      cardClass={'is-parent is-6'} />
-    <div class="tile is-parent is-6 is-vertical test">
-      {#each eventGroup.slice(1, eventGroup.length) as event, i (event.id)}
-        <GridItem
-          id={event.id}
-          imageUrl={event.imageUrls.full_url}
-          title={event.title}
-          hub={event.hub}
-          cardClass={'is-6 '} />
-      {/each}
-    </div>
-  {:else}
-    <GridItem
-      id={eventGroup[0].id}
-      imageUrl={eventGroup[0].imageUrls.full_url}
-      title={eventGroup[0].title}
-      hub={eventGroup[0].hub}
-      cardClass={'is-parent is-6'} />
-    <div class="tile is-parent is-6 is-vertical test">
-      {#each eventGroup.slice(1, eventGroup.length) as event, i (event.id)}
-        <GridItem
-          id={event.id}
-          imageUrl={event.imageUrls.full_url}
-          title={event.title}
-          hub={event.hub}
-          cardClass={'is-6 is-alone'} />
-      {/each}
-    </div>
-  {/if}
-{:else}
-  {#if eventGroup.length === 5}
-    <div class="tile is-parent is-6 is-vertical test">
-      {#each eventGroup.slice(0, eventGroup.length - 1) as event, i (event.id)}
-        <GridItem
-          id={event.id}
-          imageUrl={event.imageUrls.full_url}
-          title={event.title}
-          hub={event.hub}
-          cardClass={'is-6'} />
-      {/each}
-    </div>
-    <GridItem
-      id={eventGroup[4].id}
-      imageUrl={eventGroup[4].imageUrls.full_url}
-      title={eventGroup[4].title}
-      hub={eventGroup[4].hub}
-      cardClass={'is-parent is-6'} />
-  {:else}
-    <div class="tile is-parent is-6 is-vertical test">
-      {#each eventGroup.slice(0, eventGroup.length) as event, i (event.id)}
-        <GridItem
-          id={event.id}
-          imageUrl={event.imageUrls.full_url}
-          title={event.title}
-          hub={event.hub}
-          cardClass={'is-6'} />
-      {/each}
-    </div>
-  {/if}
+{#if isEven}
+  <GridItem event={eventGroup[0]} cardClass={'is-parent is-6'} />
+{/if}
+
+<div class="tile is-parent is-6 is-vertical test">
+  {#each eventGroup.slice(1, eventGroup.length) as event, i (event.id)}
+    {#if eventGroup.length === 5}
+      <GridItem {event} cardClass={'is-6'} />
+    {:else}
+      <GridItem {event} cardClass={'is-6 is-alone'} />
+    {/if}
+  {/each}
+</div>
+
+{#if !isEven}
+  <GridItem event={eventGroup[0]} cardClass={'is-parent is-6'} />
 {/if}

--- a/src/components/UI/Grid/GridItem.svelte
+++ b/src/components/UI/Grid/GridItem.svelte
@@ -1,0 +1,43 @@
+<script>
+  export let id = null;
+  export let imageUrl = "";
+  export let title = "";
+  export let hub = "";
+  export let index = null;
+
+  let cardClass = "";
+
+  if (index === 0) {
+    cardClass = "is-6";
+  } else if (index % 10 === 0 || (index + 1) % 10 === 0) {
+    cardClass = "is-6";
+  } else {
+    cardClass = "is-3";
+  }
+</script>
+
+<style lang="scss">
+  .card-header {
+    flex-wrap: wrap;
+    box-shadow: none;
+    text-align: center;
+  }
+  h3 {
+    width: 100%;
+    &.hub {
+      text-transform: capitalize;
+    }
+  }
+</style>
+
+<a rel="prefetch" href="/events/{id}" class="card column {cardClass}">
+  <div class="card-image">
+    <figure class="image is-3by4">
+      <img src={imageUrl} alt="{title} Poster" />
+    </figure>
+  </div>
+  <div class="card-header">
+    <h3 class="title card-header-title is-centered">{title}</h3>
+    <h3 class="hub card-header-title is-centered">{hub}</h3>
+  </div>
+</a>

--- a/src/components/UI/Grid/GridItem.svelte
+++ b/src/components/UI/Grid/GridItem.svelte
@@ -3,20 +3,19 @@
   export let imageUrl = "";
   export let title = "";
   export let hub = "";
-  export let index = null;
+  export let cardClass = '';
 
-  let cardClass = "";
-
-  if (index === 0) {
-    cardClass = "is-6";
-  } else if (index % 10 === 0 || (index + 1) % 10 === 0) {
-    cardClass = "is-6";
-  } else {
-    cardClass = "is-3";
-  }
 </script>
 
 <style lang="scss">
+  .tile {
+    &.is-child {
+      padding: 100px;
+    }
+    &.is-alone {
+      height: max-content;
+    }
+  }
   .card-header {
     flex-wrap: wrap;
     box-shadow: none;
@@ -30,14 +29,16 @@
   }
 </style>
 
-<a rel="prefetch" href="/events/{id}" class="card column {cardClass}">
-  <div class="card-image">
-    <figure class="image is-3by4">
-      <img src={imageUrl} alt="{title} Poster" />
-    </figure>
-  </div>
-  <div class="card-header">
-    <h3 class="title card-header-title is-centered">{title}</h3>
-    <h3 class="hub card-header-title is-centered">{hub}</h3>
+<a rel="prefetch" href="/events/{id}" class="tile {cardClass}">
+  <div class="tile is-child card">
+    <div class="card-image">
+      <figure class="image is-3by4">
+        <img src={imageUrl} alt="{title} Poster" />
+      </figure>
+    </div>
+    <div class="card-header">
+      <h3 class="title card-header-title is-centered">{title}</h3>
+      <h3 class="hub card-header-title is-centered">{hub}</h3>
+    </div>
   </div>
 </a>

--- a/src/components/UI/Grid/GridItem.svelte
+++ b/src/components/UI/Grid/GridItem.svelte
@@ -1,16 +1,16 @@
 <script>
-  export let id = null;
-  export let imageUrl = "";
-  export let title = "";
-  export let hub = "";
+  export let event = null;
   export let cardClass = '';
+
+  let { id, title, hub } = event;
+  let imageUrl = event.imageUrls.full_url;
 
 </script>
 
 <style lang="scss">
   .tile {
     &.is-child {
-      padding: 100px;
+      padding: 10%;
     }
     &.is-alone {
       height: max-content;

--- a/src/routes/_layout.svelte
+++ b/src/routes/_layout.svelte
@@ -1,6 +1,6 @@
 <script>
   import Nav from "../components/UI/Nav.svelte";
-  import Footer from "../components/UI/Footer.svelte"
+  import Footer from "../components/UI/Footer.svelte";
 
   export let segment;
 
@@ -26,21 +26,21 @@
   }
 
   progress {
-		top: 0;
+    top: 0;
     position: fixed;
     width: 100%;
-		height: 5px;
-		border: none;
-		background: transparent;
-		z-index: 1000;
+    height: 5px;
+    border: none;
+    background: transparent;
+    z-index: 1000;
 
-		&[value]::-webkit-progress-value {
-			background: $blue;
-		}
+    &[value]::-webkit-progress-value {
+      background: $blue;
+    }
 
-		&[value]::-moz-progress-bar {
-			background: $blue;
-		}
+    &[value]::-moz-progress-bar {
+      background: $blue;
+    }
   }
 
   .test {
@@ -53,12 +53,10 @@
 <Nav {segment} />
 <progress value={progress} />
 
-
 <div bind:clientHeight={docHeight}>
 
   <main>
     <slot />
   </main>
-
-  <Footer/>
+  <Footer />
 </div>

--- a/src/routes/events/index.svelte
+++ b/src/routes/events/index.svelte
@@ -1,35 +1,33 @@
 <script context="module">
-	export function preload({ params, query }) {
-		return this.fetch(`events.json`).then(r => r.json()).then(events => {
-			return { events };
-		});
-	}
+  export function preload({ params, query }) {
+    return this.fetch(`events.json`)
+      .then(r => r.json())
+      .then(events => {
+        return { events };
+      });
+  }
 </script>
 
 <script>
-	export let events;
+  import GridItem from "../../components/UI/Grid/GridItem.svelte";
+  export let events;
 </script>
 
-<style>
-	ul {
-		margin: 0 0 1em 0;
-		line-height: 1.5;
-	}
+<style lang="scss">
+
 </style>
 
 <svelte:head>
-	<title>Events</title>
+  <title>Events</title>
 </svelte:head>
 
-<h1>Recent events</h1>
-
-<ul>
-	{#each events as event}
-		<li>
-			<ul>
-				<li><a rel='prefetch' href="/events/{event.id}">{event.title}</a></li>
-				<li><img src="{event.imageUrls.full_url}" alt="{event.title} Poster"></li>
-			</ul>
-		</li>
-	{/each}
-</ul>
+<div class="columns is-multiline">
+  {#each events as event, i (event.id)}
+    <GridItem
+      id={event.id}
+      imageUrl={event.imageUrls.full_url}
+      title={event.title}
+      hub={event.hub}
+      index={i} />
+  {/each}
+</div>

--- a/src/routes/events/index.svelte
+++ b/src/routes/events/index.svelte
@@ -9,25 +9,31 @@
 </script>
 
 <script>
-  import GridItem from "../../components/UI/Grid/GridItem.svelte";
+  import GridGroup from "../../components/UI/Grid/GridGroup.svelte";
   export let events;
+
+  let eventsArray = events;
+  let eventGroups = [];
+	let len;
+
+
+	for  (let i = 0, len = events.length; i < len; i += 5) {
+    eventGroups.push(events.slice(i, i + 5));
+}
 </script>
 
 <style lang="scss">
-
+  .tile {
+    flex-flow: wrap !important;
+  }
 </style>
 
 <svelte:head>
   <title>Events</title>
 </svelte:head>
 
-<div class="columns is-multiline">
-  {#each events as event, i (event.id)}
-    <GridItem
-      id={event.id}
-      imageUrl={event.imageUrls.full_url}
-      title={event.title}
-      hub={event.hub}
-      index={i} />
+<div class="tile is-ancestor is-vertical">
+  {#each eventGroups as eventGroup, i}
+    <GridGroup {eventGroup} groupIndex={i} />
   {/each}
 </div>

--- a/variables.scss
+++ b/variables.scss
@@ -27,3 +27,5 @@ $link-hover: $dark-grey;
 @import "./node_modules/bulma/sass/base/_all.sass";
 @import "./node_modules/bulma/sass/grid/_all.sass";
 @import "./node_modules/bulma/sass/elements/image.sass";
+
+@import "./node_modules/bulma/sass/components/card.sass";


### PR DESCRIPTION
Adding the events index page with tiles from bulma. 

Contains the general GridItem and the GridGroup components to build the gridlayout. Should be easily reusable (with slight changes to props) for Lovecasts.

Logic is currently all via .json files, no stores used, so the events cannot easily be accessed on other pages at the moment. 

There is a branch with a session store here: #mn/session_store_events
Have to see if that is the right approach or a local/client side store can be used as well to ensure the data is shared across different pages for accessibility :)

