### PR TITLE
Adjusting the events query slightly to avoid failures during build when there is no hub

### DIFF
--- a/src/routes/events/index.json.js
+++ b/src/routes/events/index.json.js
@@ -21,7 +21,7 @@ export async function get(req, res, next) {
 						slug: event.slug,
 						title: event.name,
 						imageUrl: event.poster ? event.poster.data.thumbnails[7].url : "placeholder_events.png",
-						hub: event.hubs[0] ? event.hubs[0].hubs_id.city : null,
+						hub: event.hubs[0] && event.hubs[0].hubs_id ?  event.hubs[0].hubs_id.city : null,
 						category: event.event_type,
 						starttime: event.startdatetime
 					}))


### PR DESCRIPTION
This should make the events query more stable and hold up blow ups