### PR TITLE
Fix: Indentation of conditional for deploying staging

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -56,10 +56,10 @@ steps:
         - ./docker-compose.staging.yml
       commands:
         - docker-compose -f docker-compose.staging.yml up -d --build
-      when:
-        branch:
-          exclude:
-            - master
+    when:
+      branch:
+        exclude:
+          - master
 
   - name: build production
     image: node:12


### PR DESCRIPTION
The wrong indentation led to the step being triggered on master builds

Deploy staging step triggered during master build: https://drone.love-foundation.org/love-foundation/website/1865/1/4