### PR TITLE
Moving staging deploy to a nodeapp

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -34,7 +34,7 @@ steps:
         from_secret: directus_token
       NODE_ENV: staging
     commands:
-      - npm run export:production
+      - npm run build
     when:
       branch:
         exclude:
@@ -52,7 +52,11 @@ steps:
       port: 1312
       target: /srv/staging
       sources:
-        - ./__sapper__/export
+        - ./__sapper__/build
+        - ./static
+        - ./src
+        - ./node_modules
+        - ./Dockerfile
         - ./docker-compose.staging.yml
       commands:
         - docker-compose -f docker-compose.staging.yml up -d --build
@@ -128,35 +132,6 @@ steps:
         from_secret: directus_token
     commands:
       - npm run test
-
-  - name: build staging
-    image: node:12
-    pull: always
-    environment:
-      DIRECTUS_URL:
-        from_secret: directus_url
-      DIRECTUS_TOKEN:
-        from_secret: directus_token
-      NODE_ENV: staging
-    commands:
-      - npm run export:production
-
-  - name: deploy staging
-    image: cupcakearmy/drone-deploy
-    pull: always
-    environment:
-      PLUGIN_KEY:
-        from_secret: key
-    settings:
-      host: love-foundation.org
-      user: root
-      port: 1312
-      target: /srv/staging
-      sources:
-        - ./__sapper__/export
-        - ./docker-compose.staging.yml
-      commands:
-        - docker-compose -f docker-compose.staging.yml up -d --build
 
   - name: build production
     image: node:12

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM node:alpine
 
 WORKDIR /app
 
-COPY ./package.json .
-RUN yarn install --prod
+COPY . .
 
-ENTRYPOINT [ "yarn" ]
-CMD [ "run", "start" ]
+ENTRYPOINT [ "node" ]
+CMD [ "__sapper__/build" ]

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -6,15 +6,19 @@ networks:
 
 services:
     app:
-        image: cupcakearmy/static
+        build: .
         restart: unless-stopped
+        env_file:
+            - ./.env
+        ports:
+            - 3000:3000
         volumes:
-            - ./__sapper__/export:/srv
+            - .:/app
         networks:
             - proxy
         labels:
             - "traefik.enable=true"
-            - "traefik.port=80"
+            - "traefik.port=3000"
             - "traefik.docker.network=proxy"
             - "traefik.backend=webnew-staging"
             - "traefik.frontend.rule=Host:staging.love-foundation.org"


### PR DESCRIPTION
Instead of deploying a SSR exported application for staging, we are running a nodeapp.
This allows for easy checking of newly created content as the API is hit live.