### PR TITLE
Move the lozad observer outside the artistitem component

### DIFF
--- a/src/components/UI/ArtistItem.svelte
+++ b/src/components/UI/ArtistItem.svelte
@@ -1,18 +1,6 @@
 <script>
-  import lozad from "lozad";
-  import { onMount } from "svelte";
-
-  export let artist;
-
-  onMount(() => {
-    const observer = lozad(".lozad", {
-      loaded: function(el) {
-        // Custom implementation on a loaded element
-        el.classList.add("loaded");
-      }
-    });
-    observer.observe();
-  });
+  export let artist = {};
+  export let lazy = false;
 </script>
 
 <style lang="scss">
@@ -32,6 +20,8 @@
   :global(.loaded) {
     margin-top: 0 !important;
     opacity: 1 !important;
+    transition: margin-top 1s cubic-bezier(0.4, 0.07, 0.32, 0.94),
+      opacity 1s ease-in;
   }
 
   .column {
@@ -45,10 +35,11 @@
   class="column is-one-quarter-desktop is-one-third-tablet">
   <div>
     <figure class="image is-square">
-      <img
-        class="is-rounded lozad"
-        data-src={artist.imageUrl}
-        alt="{artist.name} Picture" />
+      {#if lazy}
+        <img class="is-rounded lozad" data-src={artist.imageUrl} alt="{artist.name} Picture" />
+      {:else}
+        <img class="is-rounded loaded" src={artist.imageUrl} alt="{artist.name} Picture" />
+      {/if}
     </figure>
     <h3 data-cy="artistName">{artist.name}</h3>
   </div>

--- a/src/routes/artists/index.svelte
+++ b/src/routes/artists/index.svelte
@@ -12,6 +12,8 @@
   import ArtistItem from "../../components/UI/ArtistItem.svelte";
   import { shuffleArray } from "../../lib/helpers/sharedFunctions.js";
   import Fuse from "fuse.js";
+  import lozad from "lozad";
+  import { onMount } from "svelte";
 
   export let artists;
 
@@ -37,6 +39,16 @@
     // ignoreFieldNorm: false,
     keys: ["id", "name", "location", "category"]
   };
+
+  onMount(() => {
+    const observer = lozad(".lozad", {
+      loaded: function(el) {
+        // Custom implementation on a loaded element
+        el.classList.add("loaded");
+      }
+    });
+    observer.observe();
+  });
 
   const fuse = new Fuse(filteredArtists, fuseOptions);
 
@@ -110,7 +122,7 @@
 </div>
 
 <div data-cy="artistGrid" class="columns is-multiline">
-  {#each currentSet as artist (artist.id)}
-    <ArtistItem {artist} />
+  {#each currentSet as artist, i (artist.id)}
+    <ArtistItem {artist} lazy={i >= 8}/>
   {/each}
 </div>


### PR DESCRIPTION
This change moves the observer needed for Lozad to work outside the artist component.

Furthermore, it only applies lozad from the third row of artists onward.