### PR TITLE
atomic deployment with symlinks

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -86,7 +86,7 @@ steps:
         from_secret: passphrase
       script:
         - "cd /srv/lf/website/staging/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
-        - mkdir -p /srv/lf/website/staging/current
+        - rm -rf /srv/lf/website/staging/current
         - ln -sfn /srv/lf/website/staging/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/staging/current
         - cd /srv/lf/website/staging/current
         - pwd
@@ -148,11 +148,8 @@ steps:
         from_secret: passphrase
       script:
         - "cd /srv/lf/website/prod/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
-        - mkdir -p /srv/lf/website/prod/current
         - ln -sfn /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod/current
         - cd /srv/lf/website/prod/current
-        - pwd
-        - ls -l
         - docker-compose -f docker-compose.prod.yml up -d --build
 
     when:
@@ -237,7 +234,6 @@ steps:
         from_secret: passphrase
       script:
         - "cd /srv/lf/website/prod/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
-        - mkdir -p /srv/lf/website/prod/current
         - ln -sfn /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod/current
         - cd /srv/lf/website/prod/current
         - docker-compose -f docker-compose.prod.yml up -d --build

--- a/.drone.yml
+++ b/.drone.yml
@@ -86,12 +86,9 @@ steps:
         from_secret: passphrase
       script:
         - "cd /srv/lf/website/staging/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
-        - rm -rf /srv/lf/website/staging/current
         - ln -sfn /srv/lf/website/staging/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/staging/current
-        - cd /srv/lf/website/staging/current
-        - pwd
-        - ls -l
-        - docker-compose -f docker-compose.staging.yml up -d --build
+        - docker-compose -f /srv/lf/website/staging/current/docker-compose.staging.yml down
+        - docker-compose -t website-staging -f /srv/lf/website/staging/current/docker-compose.staging.yml up -d --build
 
     when:
       branch:
@@ -150,7 +147,8 @@ steps:
         - "cd /srv/lf/website/prod/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
         - ln -sfn /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod/current
         - cd /srv/lf/website/prod/current
-        - docker-compose -f docker-compose.prod.yml up -d --build
+        - docker-compose -f /srv/lf/website/prod/current/docker-compose.prod.yml down
+        - docker-compose -t website-prod -f /srv/lf/website/prod/current/docker-compose.prod.yml up -d --build
 
     when:
       branch:
@@ -235,8 +233,8 @@ steps:
       script:
         - "cd /srv/lf/website/prod/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
         - ln -sfn /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod/current
-        - cd /srv/lf/website/prod/current
-        - docker-compose -f docker-compose.prod.yml up -d --build
+        - docker-compose -f /srv/lf/website/prod/current/docker-compose.prod.yml down
+        - docker-compose -t website-prod -f /srv/lf/website/prod/current/docker-compose.prod.yml up -d --build
 
 trigger:
   event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -56,7 +56,7 @@ steps:
         from_secret: key
       passphrase:
         from_secret: passphrase
-      target: /srv/lf/website/stag_releases/${DRONE_BUILD_NUMBER}
+      target: /srv/lf/website/releases/staging/${DRONE_BUILD_NUMBER}
       overwrite: true
       source:
         - ./build
@@ -85,9 +85,9 @@ steps:
       passphrase:
         from_secret: passphrase
       script:
-        - ln -sfn /srv/lf/website/stag_releases/${DRONE_BUILD_NUMBER} /srv/lf/website/stag
-        - "cd /srv/lf/website/stag_releases && ls -dt */ | tail -n +6 | xargs rm -rf"
-        - docker-compose -f /srv/lf/website/stag/docker-compose.staging.yml up -d --build
+        - ln -sfn /srv/lf/website/releases/staging/${DRONE_BUILD_NUMBER} /srv/lf/website/staging
+        - "cd /srv/lf/website/releases/staging && ls -dt */ | tail -n +6 | xargs rm -rf"
+        - docker-compose -f /srv/lf/website/staging/docker-compose.staging.yml up -d --build
     when:
       branch:
         exclude:
@@ -119,7 +119,7 @@ steps:
         from_secret: passphrase
       port:
         from_secret: port
-      target: /srv/lf/website/prod_releases/${DRONE_BUILD_NUMBER}
+      target: /srv/lf/website/releases/prod/${DRONE_BUILD_NUMBER}
       source:
         - ./build
         - ./docker-compose.prod.yml
@@ -142,8 +142,8 @@ steps:
       passphrase:
         from_secret: passphrase
       script:
-        - ln -sfn /srv/lf/website/prod_releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod
-        - "cd /srv/lf/website/prod_releases && ls -dt */ | tail -n +6 | xargs rm -rf"
+        - ln -sfn /srv/lf/website/releases/prod/${DRONE_BUILD_NUMBER} /srv/lf/website/prod
+        - "cd /srv/lf/website/releases/prod && ls -dt */ | tail -n +6 | xargs rm -rf"
         - docker-compose -f /srv/lf/website/prod/docker-compose.prod.yml up -d --build
     when:
       branch:
@@ -206,7 +206,7 @@ steps:
         from_secret: passphrase
       port:
         from_secret: port
-      target: /srv/lf/website/prod_releases/${DRONE_BUILD_NUMBER}
+      target: /srv/lf/website/releases/prod/${DRONE_BUILD_NUMBER}
       source:
         - ./build
         - ./docker-compose.prod.yml
@@ -226,8 +226,8 @@ steps:
       passphrase:
         from_secret: passphrase
       script:
-        - ln -sfn /srv/lf/website/prod_releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod
-        - "cd /srv/lf/website/prod_releases && ls -dt */ | tail -n +6 | xargs rm -rf"
+        - ln -sfn /srv/lf/website/releases/prod/${DRONE_BUILD_NUMBER} /srv/lf/website/prod
+        - "cd /srv/lf/website/releases/prod && ls -dt */ | tail -n +6 | xargs rm -rf"
         - docker-compose -f /srv/lf/website/prod/docker-compose.prod.yml up -d --build
 
 trigger:

--- a/.drone.yml
+++ b/.drone.yml
@@ -153,7 +153,7 @@ steps:
         - cd /srv/lf/website/prod/current
         - pwd
         - ls -l
-        - docker-compose -f docker-compose.prod.yml up -d --build"
+        - docker-compose -f docker-compose.prod.yml up -d --build
 
     when:
       branch:
@@ -240,7 +240,7 @@ steps:
         - mkdir -p /srv/lf/website/prod/current
         - ln -sfn /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod/current
         - cd /srv/lf/website/prod/current
-        - docker-compose -f docker-compose.prod.yml up -d --build"
+        - docker-compose -f docker-compose.prod.yml up -d --build
 
 trigger:
   event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -56,7 +56,7 @@ steps:
         from_secret: key
       passphrase:
         from_secret: passphrase
-      target: /srv/lf/website/releases/staging/${DRONE_BUILD_NUMBER}
+      target: /srv/lf/website/staging/releases/${DRONE_BUILD_NUMBER}
       overwrite: true
       source:
         - ./build
@@ -85,9 +85,9 @@ steps:
       passphrase:
         from_secret: passphrase
       script:
-        - ln -sfn /srv/lf/website/releases/staging/${DRONE_BUILD_NUMBER} /srv/lf/website/staging
-        - "cd /srv/lf/website/releases/staging && ls -dt */ | tail -n +6 | xargs rm -rf"
-        - docker-compose -f /srv/lf/website/staging/docker-compose.staging.yml up -d --build
+        - ln -sfn /srv/lf/website/staging/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/staging/current/
+        - "cd /srv/lf/website/staging/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
+        - docker-compose -f /srv/lf/website/staging/current/docker-compose.staging.yml up -d --build
     when:
       branch:
         exclude:
@@ -119,7 +119,7 @@ steps:
         from_secret: passphrase
       port:
         from_secret: port
-      target: /srv/lf/website/releases/prod/${DRONE_BUILD_NUMBER}
+      target: /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER}
       source:
         - ./build
         - ./docker-compose.prod.yml
@@ -142,9 +142,9 @@ steps:
       passphrase:
         from_secret: passphrase
       script:
-        - ln -sfn /srv/lf/website/releases/prod/${DRONE_BUILD_NUMBER} /srv/lf/website/prod
-        - "cd /srv/lf/website/releases/prod && ls -dt */ | tail -n +6 | xargs rm -rf"
-        - docker-compose -f /srv/lf/website/prod/docker-compose.prod.yml up -d --build
+        - ln -sfn  /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod/current
+        - "cd /srv/lf/website/prod/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
+        - docker-compose -f /srv/lf/website/prod/current/docker-compose.prod.yml up -d --build
     when:
       branch:
         - master
@@ -206,7 +206,7 @@ steps:
         from_secret: passphrase
       port:
         from_secret: port
-      target: /srv/lf/website/releases/prod/${DRONE_BUILD_NUMBER}
+      target: /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER}
       source:
         - ./build
         - ./docker-compose.prod.yml
@@ -226,9 +226,9 @@ steps:
       passphrase:
         from_secret: passphrase
       script:
-        - ln -sfn /srv/lf/website/releases/prod/${DRONE_BUILD_NUMBER} /srv/lf/website/prod
-        - "cd /srv/lf/website/releases/prod && ls -dt */ | tail -n +6 | xargs rm -rf"
-        - docker-compose -f /srv/lf/website/prod/docker-compose.prod.yml up -d --build
+        - ln -sfn  /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod/current
+        - "cd /srv/lf/website/prod/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
+        - docker-compose -f /srv/lf/website/prod/current/docker-compose.prod.yml up -d --build
 
 trigger:
   event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -56,7 +56,7 @@ steps:
         from_secret: key
       passphrase:
         from_secret: passphrase
-      target: /srv/lf/website/staging/deploy
+      target: /srv/lf/website/stag_releases/${DRONE_BUILD_NUMBER}
       overwrite: true
       source:
         - ./build
@@ -85,10 +85,9 @@ steps:
       passphrase:
         from_secret: passphrase
       script:
-        - cd /srv/lf/website/staging
-        - rsync -ravI ./deploy/ . --delete-after --filter="P .env"
-        - rm -rf ./deploy
-        - docker-compose -f docker-compose.staging.yml up -d --build
+        - ln -sfn /srv/lf/website/stag_releases/${DRONE_BUILD_NUMBER} /srv/lf/website/stag
+        - "cd /srv/lf/website/stag_releases && ls -dt */ | tail -n +6 | xargs rm -rf"
+        - docker-compose -f /srv/lf/website/stag/docker-compose.staging.yml up -d --build
     when:
       branch:
         exclude:
@@ -120,7 +119,7 @@ steps:
         from_secret: passphrase
       port:
         from_secret: port
-      target: /srv/lf/website/prod/deploy
+      target: /srv/lf/website/prod_releases/${DRONE_BUILD_NUMBER}
       source:
         - ./build
         - ./docker-compose.prod.yml
@@ -143,12 +142,9 @@ steps:
       passphrase:
         from_secret: passphrase
       script:
-        - pwd
-        - cd /srv/lf/website/prod
-        - pwd
-        - rsync -ravI ./deploy/ . --delete-after
-        - rm -rf ./deploy
-        - docker-compose -f docker-compose.prod.yml up -d --build
+        - ln -sfn /srv/lf/website/prod_releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod
+        - "cd /srv/lf/website/prod_releases && ls -dt */ | tail -n +6 | xargs rm -rf"
+        - docker-compose -f /srv/lf/website/prod/docker-compose.prod.yml up -d --build
     when:
       branch:
         - master
@@ -210,7 +206,7 @@ steps:
         from_secret: passphrase
       port:
         from_secret: port
-      target: /srv/lf/website/prod/deploy
+      target: /srv/lf/website/prod_releases/${DRONE_BUILD_NUMBER}
       source:
         - ./build
         - ./docker-compose.prod.yml
@@ -230,10 +226,9 @@ steps:
       passphrase:
         from_secret: passphrase
       script:
-        - cd /srv/lf/website/prod
-        - rsync -ravI ./deploy/ . --delete-after
-        - rm -rf ./deploy
-        - docker-compose -f docker-compose.prod.yml up -d --build
+        - ln -sfn /srv/lf/website/prod_releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod
+        - "cd /srv/lf/website/prod_releases && ls -dt */ | tail -n +6 | xargs rm -rf"
+        - docker-compose -f /srv/lf/website/prod/docker-compose.prod.yml up -d --build
 
 trigger:
   event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -88,7 +88,7 @@ steps:
         - "cd /srv/lf/website/staging/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
         - ln -sfn /srv/lf/website/staging/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/staging/current
         - docker-compose -f /srv/lf/website/staging/current/docker-compose.staging.yml down
-        - docker-compose -t website-staging -f /srv/lf/website/staging/current/docker-compose.staging.yml up -d --build
+        - docker-compose -f /srv/lf/website/staging/current/docker-compose.staging.yml up -d --build
 
     when:
       branch:
@@ -148,7 +148,7 @@ steps:
         - ln -sfn /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod/current
         - cd /srv/lf/website/prod/current
         - docker-compose -f /srv/lf/website/prod/current/docker-compose.prod.yml down
-        - docker-compose -t website-prod -f /srv/lf/website/prod/current/docker-compose.prod.yml up -d --build
+        - docker-compose -f /srv/lf/website/prod/current/docker-compose.prod.yml up -d --build
 
     when:
       branch:
@@ -234,7 +234,7 @@ steps:
         - "cd /srv/lf/website/prod/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
         - ln -sfn /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod/current
         - docker-compose -f /srv/lf/website/prod/current/docker-compose.prod.yml down
-        - docker-compose -t website-prod -f /srv/lf/website/prod/current/docker-compose.prod.yml up -d --build
+        - docker-compose -f /srv/lf/website/prod/current/docker-compose.prod.yml up -d --build
 
 trigger:
   event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -91,7 +91,7 @@ steps:
         - cd /srv/lf/website/staging/current
         - pwd
         - ls -l
-        - docker-compose -f docker-compose.staging.yml up -d --build"
+        - docker-compose -f docker-compose.staging.yml up -d --build
 
     when:
       branch:

--- a/.drone.yml
+++ b/.drone.yml
@@ -87,7 +87,7 @@ steps:
       script:
         - "cd /srv/lf/website/staging/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
         - ln -sfn /srv/lf/website/staging/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/staging/current
-        - docker-compose -f /srv/lf/website/staging/current/docker-compose.staging.yml up -d --build
+        - docker-compose -p staging -f /srv/lf/website/staging/current/docker-compose.staging.yml up -d --build
 
     when:
       branch:
@@ -145,8 +145,7 @@ steps:
       script:
         - "cd /srv/lf/website/prod/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
         - ln -sfn /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod/current
-        - cd /srv/lf/website/prod/current
-        - docker-compose -f /srv/lf/website/prod/current/docker-compose.prod.yml up -d --build
+        - docker-compose -p prod -f /srv/lf/website/prod/current/docker-compose.prod.yml up -d --build
 
     when:
       branch:
@@ -231,8 +230,7 @@ steps:
       script:
         - "cd /srv/lf/website/prod/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
         - ln -sfn /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod/current
-        - docker-compose -f /srv/lf/website/prod/current/docker-compose.prod.yml down
-        - docker-compose -f /srv/lf/website/prod/current/docker-compose.prod.yml up -d --build
+        - docker-compose -p prod -f /srv/lf/website/prod/current/docker-compose.prod.yml up -d --build
 
 trigger:
   event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -85,9 +85,11 @@ steps:
       passphrase:
         from_secret: passphrase
       script:
-        - ln -sfn /srv/lf/website/staging/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/staging/current/
+        - mkdir -p /srv/lf/website/staging/current
+        - ln -sfn /srv/lf/website/staging/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/staging/current
         - "cd /srv/lf/website/staging/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
-        - docker-compose -f /srv/lf/website/staging/current/docker-compose.staging.yml up -d --build
+        - "cd /srv/lf/website/staging/current && docker-compose -f docker-compose.staging.yml up -d --build"
+
     when:
       branch:
         exclude:
@@ -142,9 +144,11 @@ steps:
       passphrase:
         from_secret: passphrase
       script:
-        - ln -sfn  /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod/current
+        - mkdir -p /srv/lf/website/prod/current
+        - ln -sfn /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod/current
         - "cd /srv/lf/website/prod/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
-        - docker-compose -f /srv/lf/website/prod/current/docker-compose.prod.yml up -d --build
+        - "cd /srv/lf/website/prod/current && docker-compose -f docker-compose.prod.yml up -d --build"
+
     when:
       branch:
         - master
@@ -226,9 +230,10 @@ steps:
       passphrase:
         from_secret: passphrase
       script:
-        - ln -sfn  /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod/current
+        - mkdir -p /srv/lf/website/prod/current
+        - ln -sfn /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod/current
         - "cd /srv/lf/website/prod/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
-        - docker-compose -f /srv/lf/website/prod/current/docker-compose.prod.yml up -d --build
+        - "cd /srv/lf/website/prod/current && docker-compose -f docker-compose.prod.yml up -d --build"
 
 trigger:
   event:

--- a/.drone.yml
+++ b/.drone.yml
@@ -87,7 +87,6 @@ steps:
       script:
         - "cd /srv/lf/website/staging/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
         - ln -sfn /srv/lf/website/staging/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/staging/current
-        - docker-compose -f /srv/lf/website/staging/current/docker-compose.staging.yml down
         - docker-compose -f /srv/lf/website/staging/current/docker-compose.staging.yml up -d --build
 
     when:
@@ -147,7 +146,6 @@ steps:
         - "cd /srv/lf/website/prod/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
         - ln -sfn /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod/current
         - cd /srv/lf/website/prod/current
-        - docker-compose -f /srv/lf/website/prod/current/docker-compose.prod.yml down
         - docker-compose -f /srv/lf/website/prod/current/docker-compose.prod.yml up -d --build
 
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -85,10 +85,13 @@ steps:
       passphrase:
         from_secret: passphrase
       script:
+        - "cd /srv/lf/website/staging/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
         - mkdir -p /srv/lf/website/staging/current
         - ln -sfn /srv/lf/website/staging/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/staging/current
-        - "cd /srv/lf/website/staging/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
-        - "cd /srv/lf/website/staging/current && docker-compose -f docker-compose.staging.yml up -d --build"
+        - cd /srv/lf/website/staging/current
+        - pwd
+        - ls -l
+        - docker-compose -f docker-compose.staging.yml up -d --build"
 
     when:
       branch:
@@ -144,10 +147,13 @@ steps:
       passphrase:
         from_secret: passphrase
       script:
+        - "cd /srv/lf/website/prod/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
         - mkdir -p /srv/lf/website/prod/current
         - ln -sfn /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod/current
-        - "cd /srv/lf/website/prod/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
-        - "cd /srv/lf/website/prod/current && docker-compose -f docker-compose.prod.yml up -d --build"
+        - cd /srv/lf/website/prod/current
+        - pwd
+        - ls -l
+        - docker-compose -f docker-compose.prod.yml up -d --build"
 
     when:
       branch:
@@ -230,10 +236,11 @@ steps:
       passphrase:
         from_secret: passphrase
       script:
+        - "cd /srv/lf/website/prod/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
         - mkdir -p /srv/lf/website/prod/current
         - ln -sfn /srv/lf/website/prod/releases/${DRONE_BUILD_NUMBER} /srv/lf/website/prod/current
-        - "cd /srv/lf/website/prod/releases && ls -dt */ | tail -n +6 | xargs rm -rf"
-        - "cd /srv/lf/website/prod/current && docker-compose -f docker-compose.prod.yml up -d --build"
+        - cd /srv/lf/website/prod/current
+        - docker-compose -f docker-compose.prod.yml up -d --build"
 
 trigger:
   event:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -9,7 +9,7 @@ services:
     build: .
     restart: unless-stopped
     env_file:
-      - ./.env
+      - /srv/lf/website/staging/.env
     ports:
       - 3000:3000
     volumes:


### PR DESCRIPTION
I believe the error that is currently on the event page is again in the drone build process (or the restart of production I think) because everything worked for me locally. The current version on staging also works without error.
I was able to test on the live server, that the JSON parse error likely appears because no JSON for the event is available.
Example 1: https://love-foundation.org/events/flohmarkt/ works and has a json https://love-foundation.org/events/flohmarkt.json
Example 2: https://love-foundation.org/events/kelderlove does not work (JSON parse error) and has no json https://love-foundation.org/events/kelderlove.json
Why exactly this happens I am at a loss but I suspect it might be because of the rsync command or anything that happens inbetween?
Anyways. Rsync sucks for deployment. :-)
If this PR does not fix it, at least the deployment is nicer & faster (actually almost instantious), and also more debuggable (it's possible to go back to previous 5 releases).
LG