### PR TITLE
fix: trailingSlash for correct static deploys

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,8 +12,11 @@ services:
       - ./build:/srv
     networks:
       - proxy
+    ports:
+      - 80:80
     labels:
       - traefik.enable=true
+      - traefik.http.services.lf-website-prod.loadbalancer.server.port=80
       - traefik.http.routers.lf-website-prod.rule=Host(`www.love-foundation.org`) || Host(`love-foundation.org`)
       - traefik.http.routers.lf-website-prod.entrypoints=secure
       - traefik.http.routers.lf-website-prod.tls.certresolver=le

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,7 +12,13 @@ const config = {
 		// adapter-auto only supports some environments, see https://kit.svelte.dev/docs/adapter-auto for a list.
 		// If your environment is not supported or you settled on a specific environment, switch out the adapter.
 		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
-		adapter: process.env.ADAPTER === 'node' ? node() : adapter()
+		adapter:
+			process.env.ADAPTER === 'node'
+				? node()
+				: adapter({
+						trailingSlash: 'always',
+						precompress: true
+					})
 	}
 };
 


### PR DESCRIPTION
This should alleviate the 403 errors we're seeing on production deploys currently